### PR TITLE
fix(🔌): fallback plugin build for non-module repos

### DIFF
--- a/internal/pluginruntime/install.go
+++ b/internal/pluginruntime/install.go
@@ -78,7 +78,7 @@ func buildPluginArtifact(artifactPath, target string) error {
 	if err == nil {
 		return nil
 	}
-	if isModuleImportTarget(target) && isMissingGoModuleContext(stderr) {
+	if isModuleImportTarget(target) {
 		tempStderr, tempErr := buildInTempModule(artifactPath, target)
 		if tempErr == nil {
 			return nil
@@ -135,10 +135,6 @@ func isModuleImportTarget(target string) bool {
 		!strings.HasPrefix(target, ".") &&
 		!strings.HasPrefix(target, "/") &&
 		strings.Contains(target, ".")
-}
-
-func isMissingGoModuleContext(stderr string) bool {
-	return strings.Contains(stderr, "go.mod file not found in current directory or any parent directory")
 }
 
 func buildTarget(rp ResolvedPlugin) string {


### PR DESCRIPTION
WHY: Init lock should not depend on host repository being a go module.

SCOPE: Builtin Plugin

BUILTIN PLUGIN: always attempt temp-module fallback for module-path plugin builds instead of relying on one specific go stderr message.