### PR TITLE
fix(🔫🔌): default plugin binaries to gobin with override 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ If config already exists and you only want to refresh lock/build artifacts:
 ```bash
 goodcommit plugin lock \
   --plugins-config ./configs/goodcommit.plugins.json \
+  --plugins-bin-dir gobin \
   --plugins-lockfile ./goodcommit.plugins.lock
 ```
 
@@ -114,6 +115,7 @@ goodcommit init [flags]
 - `--plugins-config` path to scaffold plugins config (default `./configs/goodcommit.plugins.json`)
 - `--types-config` path to scaffold commit types config (default `./configs/commit-types.json`)
 - `--plugins-lockfile` lockfile output path (default `goodcommit.plugins.lock`)
+- `--plugins-bin-dir` executable output directory (default `gobin`, which resolves to `GOBIN`/Go bin dir)
 - `--lock` build+write lockfile after scaffolding (default `true`)
 - `--force` overwrite scaffold files if they already exist
 

--- a/cmd/goodcommit/main.go
+++ b/cmd/goodcommit/main.go
@@ -839,6 +839,7 @@ func runInitSubcommand(args []string) error {
 	pluginsConfigPath := fs.String("plugins-config", "./configs/goodcommit.plugins.json", "Path to write plugin config")
 	typesConfigPath := fs.String("types-config", "./configs/commit-types.json", "Path to write commit types config")
 	pluginsLockfilePath := fs.String("plugins-lockfile", "goodcommit.plugins.lock", "Path to write plugin lockfile")
+	pluginsBinDir := fs.String("plugins-bin-dir", "gobin", "Directory for built plugin executables (default: GOBIN)")
 	force := fs.Bool("force", false, "Overwrite scaffold files if they already exist")
 	withLock := fs.Bool("lock", true, "Generate plugin lockfile after scaffolding")
 	if err := fs.Parse(args); err != nil {
@@ -957,7 +958,7 @@ func runInitSubcommand(args []string) error {
 		resolved, err := plugins.LoadResolvedPlugins(*pluginsConfigPath)
 		if err != nil {
 			fmt.Printf("Warning: scaffold created but lock step failed to load plugins config: %v\n", err)
-		} else if lf, err := plugins.BuildLockfileWithArtifacts(resolved, *pluginsLockfilePath); err != nil {
+		} else if lf, err := plugins.BuildLockfileWithArtifacts(resolved, *pluginsLockfilePath, *pluginsBinDir); err != nil {
 			fmt.Printf("Warning: scaffold created but lock step failed: %v\n", err)
 		} else if err := plugins.WriteLockfile(*pluginsLockfilePath, lf); err != nil {
 			fmt.Printf("Warning: scaffold created but lockfile write failed: %v\n", err)
@@ -1004,6 +1005,7 @@ func runPluginSubcommand(args []string) error {
 		fs := flag.NewFlagSet("plugin lock", flag.ContinueOnError)
 		pluginsConfigPath := fs.String("plugins-config", "", "Path to a plugin configuration file")
 		pluginsLockfilePath := fs.String("plugins-lockfile", "goodcommit.plugins.lock", "Path to a plugin lockfile")
+		pluginsBinDir := fs.String("plugins-bin-dir", "gobin", "Directory for built plugin executables (default: GOBIN)")
 		if err := fs.Parse(args[1:]); err != nil {
 			if err == flag.ErrHelp {
 				return nil
@@ -1017,7 +1019,7 @@ func runPluginSubcommand(args []string) error {
 		if err != nil {
 			return err
 		}
-		lf, err := plugins.BuildLockfileWithArtifacts(resolved, *pluginsLockfilePath)
+		lf, err := plugins.BuildLockfileWithArtifacts(resolved, *pluginsLockfilePath, *pluginsBinDir)
 		if err != nil {
 			return err
 		}

--- a/internal/pluginruntime/install.go
+++ b/internal/pluginruntime/install.go
@@ -13,14 +13,21 @@ import (
 const projectBinDir = ".goodcommit/plugins/bin"
 
 // BuildLockfileWithArtifacts writes lock metadata plus locally built plugin executables.
-func BuildLockfileWithArtifacts(resolved []ResolvedPlugin, lockPath string) (Lockfile, error) {
+func BuildLockfileWithArtifacts(resolved []ResolvedPlugin, lockPath, binDirOverride string) (Lockfile, error) {
 	lf, err := BuildLockfileFromResolved(resolved)
 	if err != nil {
 		return Lockfile{}, err
 	}
 
 	lockDir := filepath.Dir(lockPath)
-	binDir := filepath.Join(lockDir, projectBinDir)
+	lockDirAbs, err := filepath.Abs(lockDir)
+	if err != nil {
+		return Lockfile{}, fmt.Errorf("resolve lock directory: %w", err)
+	}
+	binDir, err := resolvePluginBinDir(lockDirAbs, binDirOverride)
+	if err != nil {
+		return Lockfile{}, err
+	}
 	if err := os.MkdirAll(binDir, 0o755); err != nil {
 		return Lockfile{}, fmt.Errorf("create plugin bin directory: %w", err)
 	}
@@ -35,7 +42,7 @@ func BuildLockfileWithArtifacts(resolved []ResolvedPlugin, lockPath string) (Loc
 		if !ok {
 			continue
 		}
-		execRel, execSum, err := installExecutable(lockDir, binDir, resolvedPlugin)
+		execRel, execSum, err := installExecutable(lockDirAbs, binDir, resolvedPlugin)
 		if err != nil {
 			return Lockfile{}, err
 		}
@@ -57,6 +64,10 @@ func installExecutable(lockDir, binDir string, rp ResolvedPlugin) (string, strin
 		artifactName += ".exe"
 	}
 	artifactPath := filepath.Join(binDir, artifactName)
+	artifactPath, err := filepath.Abs(artifactPath)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve plugin artifact path %s: %w", artifactPath, err)
+	}
 
 	if err := buildPluginArtifact(artifactPath, target); err != nil {
 		return "", "", fmt.Errorf("build plugin %s: %w", rp.Runtime.Manifest.ID, err)
@@ -66,11 +77,11 @@ func installExecutable(lockDir, binDir string, rp ResolvedPlugin) (string, strin
 	if err != nil {
 		return "", "", fmt.Errorf("checksum plugin executable %s: %w", rp.Runtime.Manifest.ID, err)
 	}
-	rel, err := filepath.Rel(lockDir, artifactPath)
+	storedPath, err := pathForLockfile(lockDir, artifactPath)
 	if err != nil {
-		return "", "", fmt.Errorf("relative path for plugin executable %s: %w", rp.Runtime.Manifest.ID, err)
+		return "", "", fmt.Errorf("path for plugin executable %s: %w", rp.Runtime.Manifest.ID, err)
 	}
-	return filepath.ToSlash(rel), sum, nil
+	return storedPath, sum, nil
 }
 
 func buildPluginArtifact(artifactPath, target string) error {
@@ -135,6 +146,65 @@ func isModuleImportTarget(target string) bool {
 		!strings.HasPrefix(target, ".") &&
 		!strings.HasPrefix(target, "/") &&
 		strings.Contains(target, ".")
+}
+
+func resolvePluginBinDir(lockDir, override string) (string, error) {
+	trimmed := strings.TrimSpace(override)
+	if trimmed == "" || strings.EqualFold(trimmed, "gobin") {
+		gobin, err := discoverGoBin()
+		if err != nil {
+			return "", fmt.Errorf("resolve GOBIN: %w", err)
+		}
+		return gobin, nil
+	}
+	if strings.EqualFold(trimmed, "project") {
+		return filepath.Join(lockDir, projectBinDir), nil
+	}
+	if filepath.IsAbs(trimmed) {
+		return trimmed, nil
+	}
+	return filepath.Join(lockDir, trimmed), nil
+}
+
+func discoverGoBin() (string, error) {
+	if v := strings.TrimSpace(os.Getenv("GOBIN")); v != "" {
+		return v, nil
+	}
+
+	cmd := exec.Command("go", "env", "GOBIN")
+	if out, err := cmd.Output(); err == nil {
+		if v := strings.TrimSpace(string(out)); v != "" {
+			return v, nil
+		}
+	}
+
+	cmd = exec.Command("go", "env", "GOPATH")
+	if out, err := cmd.Output(); err == nil {
+		gopath := strings.TrimSpace(string(out))
+		if gopath != "" {
+			paths := strings.Split(gopath, string(os.PathListSeparator))
+			if len(paths) > 0 && strings.TrimSpace(paths[0]) != "" {
+				return filepath.Join(strings.TrimSpace(paths[0]), "bin"), nil
+			}
+		}
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return "", fmt.Errorf("unable to determine go bin directory")
+	}
+	return filepath.Join(home, "go", "bin"), nil
+}
+
+func pathForLockfile(lockDir, artifactPath string) (string, error) {
+	rel, err := filepath.Rel(lockDir, artifactPath)
+	if err == nil {
+		isOutside := rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator))
+		if !isOutside {
+			return filepath.ToSlash(rel), nil
+		}
+	}
+	return filepath.ToSlash(artifactPath), nil
 }
 
 func buildTarget(rp ResolvedPlugin) string {

--- a/internal/pluginruntime/install.go
+++ b/internal/pluginruntime/install.go
@@ -78,7 +78,7 @@ func buildPluginArtifact(artifactPath, target string) error {
 	if err == nil {
 		return nil
 	}
-	if isModuleImportTarget(target) && isMissingGoModuleContext(stderr) {
+	if isModuleImportTarget(target) {
 		tempStderr, tempErr := buildInTempModule(artifactPath, target)
 		if tempErr == nil {
 			return nil
@@ -135,10 +135,6 @@ func isModuleImportTarget(target string) bool {
 		!strings.HasPrefix(target, ".") &&
 		!strings.HasPrefix(target, "/") &&
 		strings.Contains(target, ".")
-}
-
-func isMissingGoModuleContext(stderr string) bool {
-	return strings.Contains(stderr, "go.mod file not found in current directory or any parent directory")
 }
 
 func buildTarget(rp ResolvedPlugin) string {


### PR DESCRIPTION
WHY: Avoid lock failures and support non-module repositories.

SCOPES: Goodcommit / Builtin Plugin

GOODCOMMIT: add plugins-bin-dir flag to init and plugin lock commands and document usage.
BUILTIN PLUGIN: use absolute artifact paths and default lock installs to GOBIN while preserving override support.

Signed-off-by: Rolando Sotelo <rola@hey.com>