### PR TITLE
fix: scope required answers to collect hooks

### DIFF
--- a/internal/pluginruntime/required_answers.go
+++ b/internal/pluginruntime/required_answers.go
@@ -62,7 +62,10 @@ func applyRequiredAnswerOverrides(manifest Manifest, requiredAnswers []string) (
 	return manifest, nil
 }
 
-func validateRequiredAnswersProvided(rp RuntimePlugin, answers map[string]interface{}) error {
+func validateRequiredAnswersProvided(hook HookPhase, rp RuntimePlugin, answers map[string]interface{}) error {
+	if hook != HookCollect {
+		return nil
+	}
 	if rp.Manifest.Contract == nil {
 		return nil
 	}

--- a/internal/pluginruntime/required_answers_test.go
+++ b/internal/pluginruntime/required_answers_test.go
@@ -65,14 +65,14 @@ func TestValidateRequiredAnswersProvided(t *testing.T) {
 		},
 	}
 
-	if err := validateRequiredAnswersProvided(rp, map[string]interface{}{
+	if err := validateRequiredAnswersProvided(HookCollect, rp, map[string]interface{}{
 		"commit_body": "details",
 		"is_breaking": false,
 	}); err != nil {
 		t.Fatalf("validateRequiredAnswersProvided() unexpected error: %v", err)
 	}
 
-	err := validateRequiredAnswersProvided(rp, map[string]interface{}{
+	err := validateRequiredAnswersProvided(HookCollect, rp, map[string]interface{}{
 		"commit_body": "",
 		"is_breaking": true,
 	})
@@ -81,5 +81,22 @@ func TestValidateRequiredAnswersProvided(t *testing.T) {
 	}
 	if !isRequiredAnswerError(err) {
 		t.Fatalf("expected required-answer classification")
+	}
+}
+
+func TestValidateRequiredAnswersProvidedSkipsNonCollectHooks(t *testing.T) {
+	rp := RuntimePlugin{
+		Manifest: Manifest{
+			ID: "example/plugin",
+			Contract: &api.PluginContract{
+				Answers: []api.AIAnswerSpec{
+					{Key: "commit_scopes", Type: "[]string", Required: true},
+				},
+			},
+		},
+	}
+
+	if err := validateRequiredAnswersProvided(HookEnrich, rp, nil); err != nil {
+		t.Fatalf("validateRequiredAnswersProvided() should skip non-collect hooks: %v", err)
 	}
 }

--- a/internal/pluginruntime/runner.go
+++ b/internal/pluginruntime/runner.go
@@ -168,7 +168,7 @@ func (r *Runner) runGroupedUIPlugins(ctx context.Context, hook HookPhase, draft 
 		}
 
 		if len(invocation.Response.UIRequests) == 0 {
-			if err := validateRequiredAnswersProvided(rp, req.Answers); err != nil {
+			if err := validateRequiredAnswersProvided(hook, rp, req.Answers); err != nil {
 				return results, false, err
 			}
 			if invocation.Response.Mutations != nil {
@@ -249,7 +249,7 @@ func (r *Runner) invokeWithPrompts(ctx context.Context, rp RuntimePlugin, req Re
 		}
 
 		if len(invocation.Response.PromptRequests) == 0 && len(invocation.Response.UIRequests) == 0 {
-			if err := validateRequiredAnswersProvided(rp, req.Answers); err != nil {
+			if err := validateRequiredAnswersProvided(req.Hook, rp, req.Answers); err != nil {
 				return Invocation{}, err
 			}
 			return invocation, nil

--- a/internal/pluginruntime/runner_required_answers_hook_scope_test.go
+++ b/internal/pluginruntime/runner_required_answers_hook_scope_test.go
@@ -1,0 +1,54 @@
+package pluginruntime
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	api "github.com/rolasotelo/goodcommit/pkg/pluginapi"
+)
+
+func TestRunPhaseSkipsRequiredAnswersOnNonCollectHooks(t *testing.T) {
+	repoDir := t.TempDir()
+	pluginScript := filepath.Join(t.TempDir(), "plugin-no-ui.sh")
+	script := `#!/bin/sh
+req="$(cat)"
+id=$(printf "%s" "$req" | sed -n 's/.*"request_id":"\([^"]*\)".*/\1/p')
+printf '{"request_id":"%s","ok":true,"diagnostics":[]}\n' "$id"
+`
+	if err := os.WriteFile(pluginScript, []byte(script), 0o755); err != nil {
+		t.Fatalf("write plugin script: %v", err)
+	}
+
+	runner := NewRunner()
+	draft := CommitDraft{Metadata: map[string]interface{}{}}
+	reqCtx := RequestContext{RepoRoot: repoDir}
+	rp := RuntimePlugin{
+		Manifest: Manifest{
+			APIVersion: "goodcommit.io/v1",
+			Kind:       "Plugin",
+			ID:         "test/scopes-like",
+			Version:    "1.0.0",
+			Entrypoint: EntryPoint{
+				Type:    "exec",
+				Command: pluginScript,
+			},
+			Hooks: []HookPhase{HookCollect, HookEnrich},
+			Contract: &api.PluginContract{
+				Answers: []api.AIAnswerSpec{
+					{Key: "commit_scopes", Type: "[]string", Required: true},
+				},
+			},
+		},
+		FailureMode: FailClosed,
+	}
+
+	results, err := runner.RunPhase(context.Background(), HookEnrich, &draft, reqCtx, []RuntimePlugin{rp})
+	if err != nil {
+		t.Fatalf("RunPhase(HookEnrich) unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("RunPhase(HookEnrich) results = %d, want 1", len(results))
+	}
+}


### PR DESCRIPTION
## Summary
- limit `required_answers` validation to the `collect` phase
- prevent multi-hook plugins like `builtin/scopes` from failing on later hooks after answers are already converted into draft metadata
- add regression tests for collect-only validation and a scopes-like enrich path

## Validation
- go test ./...
- go build ./...