### PR TITLE
Fix plugin runtime edge cases and add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      GOBIN: ${{ runner.temp }}/gobin
+      GOODCOMMIT_CI_LOCKFILE: ${{ runner.temp }}/goodcommit.plugins.lock
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run tests
+        run: go test ./...
+
+      - name: Build
+        run: go build ./...
+
+      - name: Generate plugin lockfile
+        run: >
+          go run ./cmd/goodcommit plugin lock
+          --plugins-config ./configs/goodcommit.plugins.json
+          --plugins-lockfile "${GOODCOMMIT_CI_LOCKFILE}"
+
+      - name: Verify generated plugin lockfile
+        run: >
+          go run ./cmd/goodcommit plugin verify
+          --plugins-config ./configs/goodcommit.plugins.json
+          --plugins-lockfile "${GOODCOMMIT_CI_LOCKFILE}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+Target release: `v0.3.2`
+
+### Added
+
+- GitHub Actions CI workflow for pushes, pull requests, and manual runs that executes the repository validation suite.
+- Non-interactive CLI integration tests covering a simple built-in flow, a grouped flow with breaking-change metadata, and failure on missing required answers.
+
+### Changed
+
+- Plugin protocol compatibility is now enforced before execution, so manifests that do not advertise protocol `1.0` fail fast with a clear error.
+- Permission flags and docs now explicitly describe plugin permissions as approval signals, not OS-level sandboxing.
+- `plugin verify` now requires direct executable `source.type=path` plugins to be pinned in the lockfile. Older lockfiles for those plugins must be regenerated.
+
+### Fixed
+
+- Built-in text normalization now lowercases the first rune instead of the first byte, preserving UTF-8 commit text in description, body, why, and breaking-message plugins.
+- `plugin lock` now builds local Go `source.type=path` plugins from the plugin's own module or package directory, even when the caller repository is not a Go module.
+- Direct executable `source.type=path` plugins are now locked and verified using executable metadata instead of silently skipping integrity checks.
+
+### Upgrade Notes
+
+- Rebuild `goodcommit.plugins.lock` after upgrading:
+
+  ```bash
+  goodcommit plugin lock \
+    --plugins-config ./configs/goodcommit.plugins.json \
+    --plugins-lockfile ./goodcommit.plugins.lock
+  ```
+
+- If you maintain custom plugin manifests, ensure `protocol_versions` includes `"1.0"` until a newer negotiated protocol is supported end-to-end.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ goodcommit plugin context \
 
 Built-in plugins can omit explicit `manifest`/`source` in config; runtime resolves them from embedded built-in definitions.
 
+Permission note:
+- The `--allow-plugin-*` flags approve manifest-declared access categories, but they do not OS-sandbox plugin subprocesses.
+- Treat plugins as trusted code unless/until stronger sandboxing lands.
+
 You can force specific plugin answer keys to be mandatory via `required_answers` on that plugin config entry. Example:
 
 ```json

--- a/cmd/goodcommit-plugin-body/main.go
+++ b/cmd/goodcommit-plugin-body/main.go
@@ -53,8 +53,7 @@ func normalizeBody(body string) string {
 	if body == "" {
 		return ""
 	}
-	first := strings.ToUpper(body[:1])
-	body = first + body[1:]
+	body = pluginutil.UppercaseFirstRune(body)
 	if !strings.HasSuffix(body, ".") && !strings.HasSuffix(body, "!") && !strings.HasSuffix(body, "?") {
 		body += "."
 	}

--- a/cmd/goodcommit-plugin-breakingmsg/main.go
+++ b/cmd/goodcommit-plugin-breakingmsg/main.go
@@ -99,6 +99,6 @@ func normalizeSentence(s string) string {
 	if s == "" {
 		return ""
 	}
-	s = strings.ToUpper(s[:1]) + s[1:]
+	s = pluginutil.UppercaseFirstRune(s)
 	return s + "."
 }

--- a/cmd/goodcommit-plugin-description/main.go
+++ b/cmd/goodcommit-plugin-description/main.go
@@ -37,7 +37,7 @@ func run() error {
 			pluginutil.AddError(&resp, "DESCRIPTION_REQUIRED", "description is required")
 			return pluginutil.WriteResponse(resp)
 		}
-		desc = strings.ToLower(desc[:1]) + desc[1:]
+		desc = pluginutil.LowercaseFirstRune(desc)
 		resp.Mutations = &plugins.Mutations{MetadataPatch: map[string]interface{}{"gc.description": desc}}
 		pluginutil.AddInfo(&resp, "DESCRIPTION_SET", "commit description captured")
 		return pluginutil.WriteResponse(resp)

--- a/cmd/goodcommit-plugin-why/main.go
+++ b/cmd/goodcommit-plugin-why/main.go
@@ -74,7 +74,7 @@ func normalizeSentence(s string) string {
 	if s == "" {
 		return ""
 	}
-	s = strings.ToUpper(s[:1]) + s[1:]
+	s = pluginutil.UppercaseFirstRune(s)
 	return s + "."
 }
 

--- a/cmd/goodcommit/main.go
+++ b/cmd/goodcommit/main.go
@@ -17,10 +17,10 @@ Flags:
 	--plugins-config       Path to a plugin configuration file
 	--plugins-lockfile     Path to a plugin lockfile (default: goodcommit.plugins.lock)
 	--plugins-skip-verify  Skip plugin lockfile verification
-	--allow-plugin-network Allow plugins that request network permission
-	--allow-plugin-git-write Allow plugins that request git_write permission
-	--allow-plugin-filesystem-write Allow plugins that request filesystem_write permission
-	--allow-plugin-secrets Allow plugins that request secrets permission
+	--allow-plugin-network Allow plugins that declare network permission (policy only; no OS sandbox)
+	--allow-plugin-git-write Allow plugins that declare git_write permission (policy only; no OS sandbox)
+	--allow-plugin-filesystem-write Allow plugins that declare filesystem_write permission (policy only; no OS sandbox)
+	--allow-plugin-secrets Allow plugins that declare secrets permission (policy only; no OS sandbox)
 	--plugin-answer        Provide answer for plugin prompts/forms as key=value (repeatable)
 	--retry                Retry commit with the last saved commit message
 	--edit                 Edit the last saved commit message
@@ -98,10 +98,10 @@ func main() {
 	flag.StringVar(&pluginsLockfilePath, "plugins-lockfile", pluginsLockfilePath, "Path to a plugin lockfile")
 
 	pluginsSkipVerify := flag.Bool("plugins-skip-verify", false, "Skip plugin lockfile verification")
-	allowPluginNetwork := flag.Bool("allow-plugin-network", false, "Allow plugins that request network permission")
-	allowPluginGitWrite := flag.Bool("allow-plugin-git-write", false, "Allow plugins that request git_write permission")
-	allowPluginFilesystemWrite := flag.Bool("allow-plugin-filesystem-write", false, "Allow plugins that request filesystem_write permission")
-	allowPluginSecrets := flag.Bool("allow-plugin-secrets", false, "Allow plugins that request secrets permission")
+	allowPluginNetwork := flag.Bool("allow-plugin-network", false, "Allow plugins that declare network permission (policy only; no OS sandbox)")
+	allowPluginGitWrite := flag.Bool("allow-plugin-git-write", false, "Allow plugins that declare git_write permission (policy only; no OS sandbox)")
+	allowPluginFilesystemWrite := flag.Bool("allow-plugin-filesystem-write", false, "Allow plugins that declare filesystem_write permission (policy only; no OS sandbox)")
+	allowPluginSecrets := flag.Bool("allow-plugin-secrets", false, "Allow plugins that declare secrets permission (policy only; no OS sandbox)")
 	messageOverride := flag.String("message", "", "Use an initial commit message before plugin phases")
 	var pluginAnswers pluginAnswerFlag
 	flag.Var(&pluginAnswers, "plugin-answer", "Provide answer for plugin prompts/forms as key=value (repeatable)")
@@ -217,6 +217,9 @@ func main() {
 	runner.AllowPluginGitWrite = *allowPluginGitWrite
 	runner.AllowFilesystemWrite = *allowPluginFilesystemWrite
 	runner.AllowPluginSecrets = *allowPluginSecrets
+	if *allowPluginNetwork || *allowPluginGitWrite || *allowPluginFilesystemWrite || *allowPluginSecrets {
+		fmt.Fprintln(os.Stderr, "Warning: goodcommit permission flags gate manifest declarations only; plugin processes are not OS-sandboxed. Run only trusted plugins.")
+	}
 
 	invocations, err := runPluginPhases(context.Background(), runner, runtimePlugins, reqCtx, &draft, []plugins.HookPhase{
 		plugins.HookCollect,

--- a/cmd/goodcommit/noninteractive_test.go
+++ b/cmd/goodcommit/noninteractive_test.go
@@ -1,0 +1,354 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestGoodcommitHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_GOODCOMMIT_HELPER") != "1" {
+		return
+	}
+
+	sep := -1
+	for i, arg := range os.Args {
+		if arg == "--" {
+			sep = i
+			break
+		}
+	}
+	if sep == -1 {
+		os.Exit(2)
+	}
+
+	os.Args = append([]string{"goodcommit"}, os.Args[sep+1:]...)
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
+	flag.CommandLine.SetOutput(io.Discard)
+	main()
+	os.Exit(0)
+}
+
+func TestGoodcommitNonInteractiveSimpleFlow(t *testing.T) {
+	repoDir := setupGoodcommitRepo(t)
+	writeJSONFile(t, filepath.Join(repoDir, "configs", "commit-types.json"), map[string]any{
+		"types": []map[string]any{
+			{"id": "feat", "name": "Feat", "title": "Feature", "emoji": "✨"},
+		},
+	})
+
+	typesPlugin := builtinPluginConfig(t, "types", 10, "fail_closed", map[string]any{"path": "./configs/commit-types.json"})
+	descriptionPlugin := builtinPluginConfig(t, "description", 20, "fail_closed", map[string]any{})
+	bodyPlugin := builtinPluginConfig(t, "body", 30, "fail_closed", map[string]any{})
+	bodyPlugin["required_answers"] = []string{"commit_body"}
+	titlePlugin := builtinPluginConfig(t, "conventional-title", 90, "fail_closed", map[string]any{})
+	signoffPlugin := builtinPluginConfig(t, "signedoffby", 100, "fail_closed", map[string]any{"trailer_key": "Signed-off-by"})
+
+	writeJSONFile(t, filepath.Join(repoDir, "configs", "goodcommit.plugins.json"), map[string]any{
+		"plugins": []map[string]any{
+			typesPlugin,
+			descriptionPlugin,
+			bodyPlugin,
+			titlePlugin,
+			signoffPlugin,
+		},
+	})
+
+	lockGoodcommitPlugins(t, repoDir)
+
+	stdout, stderr, code := runGoodcommit(t, repoDir,
+		"--plugins-config", "./configs/goodcommit.plugins.json",
+		"--plugins-lockfile", "./goodcommit.plugins.lock",
+		"-m",
+		"--plugin-answer", "commit_type=feat",
+		"--plugin-answer", "commit_description=Ñormalize protocol handling",
+		"--plugin-answer", "commit_body=áccent aware normalization",
+	)
+	if code != 0 {
+		t.Fatalf("goodcommit exited with %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+
+	got := finalMessageFromOutput(t, stdout)
+	want := "feat: ñormalize protocol handling\n\nÁccent aware normalization.\n\nSigned-off-by: Test User <test@example.com>\n"
+	if got != want {
+		t.Fatalf("final message mismatch\nstdout:\n%s\nwant:\n%q\ngot:\n%q", stdout, want, got)
+	}
+}
+
+func TestGoodcommitNonInteractiveGroupedBreakingFlow(t *testing.T) {
+	repoDir := setupGoodcommitRepo(t)
+	writeFile(t, filepath.Join(repoDir, "configs", "logo.ascii.txt"), "GOODCOMMIT\n")
+	writeJSONFile(t, filepath.Join(repoDir, "configs", "commit-types.json"), map[string]any{
+		"types": []map[string]any{
+			{"id": "feat", "name": "Feat", "title": "Feature", "emoji": "✨"},
+		},
+	})
+	writeJSONFile(t, filepath.Join(repoDir, "configs", "commit-scopes.json"), map[string]any{
+		"scopes": []map[string]any{
+			{"id": "api", "name": "API", "description": "External interface", "emoji": "🚀", "conditional": []string{"feat"}},
+			{"id": "cli", "name": "CLI", "description": "Command-line UX", "emoji": "🖥", "conditional": []string{"feat"}},
+		},
+	})
+	writeJSONFile(t, filepath.Join(repoDir, "configs", "commit-coauthors.json"), map[string]any{
+		"coauthors": []map[string]any{
+			{"id": "test@example.com", "name": "Test User", "emoji": "🧑"},
+			{"id": "pair@example.com", "name": "Pair Programmer", "emoji": "🤝"},
+		},
+	})
+
+	logoPlugin := builtinPluginConfig(t, "logo", 1, "fail_open", map[string]any{"path": "./configs/logo.ascii.txt"})
+	logoPlugin["ui_group"] = "intro"
+	typesPlugin := builtinPluginConfig(t, "types", 10, "fail_closed", map[string]any{"path": "./configs/commit-types.json"})
+	typesPlugin["ui_group"] = "intro"
+	scopesPlugin := builtinPluginConfig(t, "scopes", 20, "fail_closed", map[string]any{"path": "./configs/commit-scopes.json"})
+	descriptionPlugin := builtinPluginConfig(t, "description", 30, "fail_closed", map[string]any{})
+	descriptionPlugin["ui_group"] = "compose_message"
+	whyPlugin := builtinPluginConfig(t, "why", 40, "fail_closed", map[string]any{"required": false})
+	whyPlugin["ui_group"] = "compose_message"
+	bodyPlugin := builtinPluginConfig(t, "body", 50, "fail_closed", map[string]any{})
+	bodyPlugin["ui_group"] = "compose_message"
+	bodyPlugin["required_answers"] = []string{"commit_body"}
+	breakingPlugin := builtinPluginConfig(t, "breaking", 60, "fail_closed", map[string]any{})
+	breakingPlugin["ui_group"] = "compose_message"
+	breakingMsgPlugin := builtinPluginConfig(t, "breakingmsg", 70, "fail_closed", map[string]any{})
+	coauthorsPlugin := builtinPluginConfig(t, "coauthors", 80, "fail_closed", map[string]any{"path": "./configs/commit-coauthors.json"})
+	titlePlugin := builtinPluginConfig(t, "conventional-title", 90, "fail_closed", map[string]any{})
+	signoffPlugin := builtinPluginConfig(t, "signedoffby", 100, "fail_closed", map[string]any{"trailer_key": "Signed-off-by"})
+
+	writeJSONFile(t, filepath.Join(repoDir, "configs", "goodcommit.plugins.json"), map[string]any{
+		"plugins": []map[string]any{
+			logoPlugin,
+			typesPlugin,
+			scopesPlugin,
+			descriptionPlugin,
+			whyPlugin,
+			bodyPlugin,
+			breakingPlugin,
+			breakingMsgPlugin,
+			coauthorsPlugin,
+			titlePlugin,
+			signoffPlugin,
+		},
+	})
+
+	lockGoodcommitPlugins(t, repoDir)
+
+	stdout, stderr, code := runGoodcommit(t, repoDir,
+		"--plugins-config", "./configs/goodcommit.plugins.json",
+		"--plugins-lockfile", "./goodcommit.plugins.lock",
+		"-m",
+		"--plugin-answer", "builtin/types.types.commit_type=feat",
+		"--plugin-answer", "commit_scopes=api,cli",
+		"--plugin-answer", "commit_description=Introduce protocol support",
+		"--plugin-answer", "commit_why=avoid confusing runtime failures",
+		"--plugin-answer", "builtin/body.body.commit_body=document plugin compatibility changes",
+		"--plugin-answer", "builtin/breaking.breaking.is_breaking=true",
+		"--plugin-answer", "breaking_message=clients must regenerate lockfiles before upgrading",
+		"--plugin-answer", "coauthors_selected=pair@example.com",
+	)
+	if code != 0 {
+		t.Fatalf("goodcommit exited with %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+
+	got := finalMessageFromOutput(t, stdout)
+	want := strings.Join([]string{
+		"feat(🚀🖥)!: introduce protocol support",
+		"",
+		"WHY: Avoid confusing runtime failures.",
+		"",
+		"SCOPES: API / CLI",
+		"",
+		"Document plugin compatibility changes.",
+		"",
+		"BREAKING CHANGE: Clients must regenerate lockfiles before upgrading.",
+		"",
+		"🧑 🤝",
+		"",
+		"Co-authored-by: Pair Programmer <pair@example.com>",
+		"Signed-off-by: Test User <test@example.com>",
+		"",
+	}, "\n")
+	if got != want {
+		t.Fatalf("final message mismatch\nstdout:\n%s\nwant:\n%q\ngot:\n%q", stdout, want, got)
+	}
+}
+
+func TestGoodcommitNonInteractiveMissingRequiredAnswerFails(t *testing.T) {
+	repoDir := setupGoodcommitRepo(t)
+	writeJSONFile(t, filepath.Join(repoDir, "configs", "commit-types.json"), map[string]any{
+		"types": []map[string]any{
+			{"id": "feat", "name": "Feat", "title": "Feature", "emoji": "✨"},
+		},
+	})
+
+	typesPlugin := builtinPluginConfig(t, "types", 10, "fail_closed", map[string]any{"path": "./configs/commit-types.json"})
+	descriptionPlugin := builtinPluginConfig(t, "description", 20, "fail_closed", map[string]any{})
+	descriptionPlugin["ui_group"] = "compose_message"
+	bodyPlugin := builtinPluginConfig(t, "body", 30, "fail_closed", map[string]any{})
+	bodyPlugin["ui_group"] = "compose_message"
+	bodyPlugin["required_answers"] = []string{"commit_body"}
+	titlePlugin := builtinPluginConfig(t, "conventional-title", 90, "fail_closed", map[string]any{})
+
+	writeJSONFile(t, filepath.Join(repoDir, "configs", "goodcommit.plugins.json"), map[string]any{
+		"plugins": []map[string]any{
+			typesPlugin,
+			descriptionPlugin,
+			bodyPlugin,
+			titlePlugin,
+		},
+	})
+
+	lockGoodcommitPlugins(t, repoDir)
+
+	stdout, stderr, code := runGoodcommit(t, repoDir,
+		"--plugins-config", "./configs/goodcommit.plugins.json",
+		"--plugins-lockfile", "./goodcommit.plugins.lock",
+		"-m",
+		"--plugin-answer", "commit_type=feat",
+		"--plugin-answer", "commit_description=Handle missing body",
+	)
+	if code == 0 {
+		t.Fatalf("expected goodcommit failure\nstdout:\n%s\nstderr:\n%s", stdout, stderr)
+	}
+
+	combined := stdout + "\n" + stderr
+	if !strings.Contains(combined, "commit_body") || !strings.Contains(combined, "missing required answers") {
+		t.Fatalf("unexpected failure output:\n%s", combined)
+	}
+}
+
+func setupGoodcommitRepo(t *testing.T) string {
+	t.Helper()
+
+	repoDir := t.TempDir()
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.name", "Test User")
+	runGit(t, repoDir, "config", "user.email", "test@example.com")
+	writeFile(t, filepath.Join(repoDir, "README.md"), "staged change\n")
+	runGit(t, repoDir, "add", "README.md")
+	return repoDir
+}
+
+func lockGoodcommitPlugins(t *testing.T, repoDir string) {
+	t.Helper()
+
+	stdout, stderr, code := runGoodcommit(t, repoDir,
+		"plugin", "lock",
+		"--plugins-config", "./configs/goodcommit.plugins.json",
+		"--plugins-lockfile", "./goodcommit.plugins.lock",
+		"--plugins-bin-dir", "project",
+	)
+	if code != 0 {
+		t.Fatalf("plugin lock failed with %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+
+	stdout, stderr, code = runGoodcommit(t, repoDir,
+		"plugin", "verify",
+		"--plugins-config", "./configs/goodcommit.plugins.json",
+		"--plugins-lockfile", "./goodcommit.plugins.lock",
+	)
+	if code != 0 {
+		t.Fatalf("plugin verify failed with %d\nstdout:\n%s\nstderr:\n%s", code, stdout, stderr)
+	}
+}
+
+func runGoodcommit(t *testing.T, repoDir string, args ...string) (string, string, int) {
+	t.Helper()
+
+	cmdArgs := append([]string{"-test.run=TestGoodcommitHelperProcess", "--"}, args...)
+	cmd := exec.Command(os.Args[0], cmdArgs...)
+	cmd.Dir = repoDir
+	cmd.Env = append(os.Environ(), "GO_WANT_GOODCOMMIT_HELPER=1")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err == nil {
+		return stdout.String(), stderr.String(), 0
+	}
+
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		t.Fatalf("runGoodcommit() unexpected error: %v", err)
+	}
+	return stdout.String(), stderr.String(), exitErr.ExitCode()
+}
+
+func runGit(t *testing.T, repoDir string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repoDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\noutput:\n%s", strings.Join(args, " "), err, string(output))
+	}
+	return string(output)
+}
+
+func writeJSONFile(t *testing.T, path string, value interface{}) {
+	t.Helper()
+
+	raw, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		t.Fatalf("MarshalIndent(%s) error = %v", path, err)
+	}
+	writeFile(t, path, string(append(raw, '\n')))
+}
+
+func writeFile(t *testing.T, path, contents string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s) error = %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", path, err)
+	}
+}
+
+func finalMessageFromOutput(t *testing.T, stdout string) string {
+	t.Helper()
+
+	const marker = "Final commit message:\n"
+	idx := strings.Index(stdout, marker)
+	if idx == -1 {
+		t.Fatalf("final message marker not found in output:\n%s", stdout)
+	}
+	message := stdout[idx+len(marker):]
+	return strings.TrimSuffix(message, "\n")
+}
+
+func builtinPluginConfig(t *testing.T, name string, order int, failureMode string, config map[string]any) map[string]any {
+	t.Helper()
+
+	return map[string]any{
+		"id":           "builtin/" + name,
+		"enabled":      true,
+		"source":       map[string]any{"type": "path", "path": filepath.Join(repoRoot(t), "cmd", "goodcommit-plugin-"+name)},
+		"order":        order,
+		"failure_mode": failureMode,
+		"timeout_ms":   10000,
+		"config":       config,
+	}
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller(0) failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", ".."))
+}

--- a/docs/plugin-lockfile-v1.md
+++ b/docs/plugin-lockfile-v1.md
@@ -34,6 +34,7 @@ The lockfile stores resolved plugin sources and checksums for reproducibility.
 ## Workflow
 
 1. Install/resolve plugin source (`path`, `git`, or `builtin`) and build executable artifacts into `.goodcommit/plugins/bin`.
+   Direct executable `path` plugins are pinned by checksum even when they are not rebuilt.
 2. Read plugin manifest and compute checksum.
 3. Upsert lockfile entry.
 4. At runtime, verify source, manifest, and executable checksums before execution.

--- a/docs/plugin-system-v1.md
+++ b/docs/plugin-system-v1.md
@@ -101,6 +101,7 @@ Core should enforce:
 - Versioned protocol: `protocol_version` (example: `"1.0"`).
 - Plugin advertises supported versions in handshake.
 - Core chooses highest mutually supported version.
+- Current runtime supports protocol `1.0` and rejects manifests that do not list it.
 - Unknown fields are ignored (forward compatibility).
 
 ## Security Model
@@ -120,6 +121,8 @@ Core policy:
 - Show permission prompts for untrusted plugins.
 - Persist trust decisions.
 - Store plugin source checksums in a lock file.
+- Current implementation gates only manifest-declared permissions; it does not OS-sandbox plugin subprocesses.
+- Users should treat plugins as trusted code until stronger isolation is implemented.
 
 ## Distribution and Discovery
 

--- a/goodcommit.plugins.lock
+++ b/goodcommit.plugins.lock
@@ -10,7 +10,7 @@
       },
       "manifest_checksum": "sha256:3b3a424abac399f7181c8bdd6b5320836c1f07a990c938bf6ff699df2aba3fe8",
       "executable_path": "gobin:builtin-body-3b3a424abac3",
-      "executable_checksum": "sha256:2aa55bc258d3b1b2ece3c5780b980e5e28c4990a8e5bb9f0780b7b12fc12cfde",
+      "executable_checksum": "sha256:d7df011dfcf970c6da118597340b485fe6cd295705ce1d39ef2db49f2dcdac20",
       "hooks": [
         "collect"
       ],
@@ -32,7 +32,7 @@
           }
         ]
       },
-      "updated_at_utc": "2026-03-03T00:27:41Z"
+      "updated_at_utc": "2026-03-07T00:41:52Z"
     },
     {
       "id": "builtin/breaking",
@@ -43,7 +43,7 @@
       },
       "manifest_checksum": "sha256:ccb7ee6066475ce45a51e7a04eb3686badd3a5ea6fdd209d9110db998209a6f3",
       "executable_path": "gobin:builtin-breaking-ccb7ee606647",
-      "executable_checksum": "sha256:309a63559860e8f1367a6c22745b9d153583b1a66b09da02eb4a578d7f3228aa",
+      "executable_checksum": "sha256:5e3dd4404f502cc61b2627028ab5204949ee87bc46d97c39cf23143ed6f7f822",
       "hooks": [
         "collect"
       ],
@@ -80,7 +80,7 @@
       "ai_auto_answers": {
         "is_breaking": false
       },
-      "updated_at_utc": "2026-03-03T00:27:41Z"
+      "updated_at_utc": "2026-03-07T00:41:52Z"
     },
     {
       "id": "builtin/breakingmsg",
@@ -91,7 +91,7 @@
       },
       "manifest_checksum": "sha256:21421a65e8a988a2625ab1e198e24f5f80b332d000d422af3f6121946a4882c2",
       "executable_path": "gobin:builtin-breakingmsg-21421a65e8a9",
-      "executable_checksum": "sha256:dd6bac207629ec2e40df6f9baed163e340a4b3f7195db071da102780a807e4ea",
+      "executable_checksum": "sha256:b5ad0e2893fcb8cf3a4fb144a275324fdb99f9faa29acfe0b7a335b553d2a08f",
       "hooks": [
         "collect",
         "enrich"
@@ -126,7 +126,7 @@
           }
         ]
       },
-      "updated_at_utc": "2026-03-03T00:27:41Z"
+      "updated_at_utc": "2026-03-07T00:41:52Z"
     },
     {
       "id": "builtin/coauthors",
@@ -137,7 +137,7 @@
       },
       "manifest_checksum": "sha256:ab995a805c5813846bdbec444cd02ccab322977dcb8435e39cebe34948150a5c",
       "executable_path": "gobin:builtin-coauthors-ab995a805c58",
-      "executable_checksum": "sha256:5f6cf5c9f52c21d96d7341b61c5f8cc8694c78cd8a5efb3cadc27862069e4b92",
+      "executable_checksum": "sha256:620aa34012630379cb378ca38c5bed9381d72c054eb8123f5e7eab3b3ce929ae",
       "hooks": [
         "collect",
         "finalize"
@@ -192,7 +192,7 @@
       "ai_auto_answers": {
         "coauthors_selected": []
       },
-      "updated_at_utc": "2026-03-03T00:27:41Z"
+      "updated_at_utc": "2026-03-07T00:41:52Z"
     },
     {
       "id": "builtin/conventional-title",
@@ -203,7 +203,7 @@
       },
       "manifest_checksum": "sha256:daff04b494a2d6baddec4df923c2c0826fe002314364b884772897dd053069f0",
       "executable_path": "gobin:builtin-conventional-title-daff04b494a2",
-      "executable_checksum": "sha256:a4e681ad28bd11328ac86cec428713abe9a7c73ce6b613d29c3cc27e82c3a770",
+      "executable_checksum": "sha256:4745c07fac9ee5cd2edbc1a04daae7a22227356b9a89f7ce20eb48ea78633a3c",
       "hooks": [
         "finalize"
       ],
@@ -236,7 +236,7 @@
           }
         ]
       },
-      "updated_at_utc": "2026-03-03T00:27:41Z"
+      "updated_at_utc": "2026-03-07T00:41:52Z"
     },
     {
       "id": "builtin/description",
@@ -247,7 +247,7 @@
       },
       "manifest_checksum": "sha256:48ddec02178d88f5b862e5a40b75b7c678e857ae70c71d1a159fb1065a8d8314",
       "executable_path": "gobin:builtin-description-48ddec02178d",
-      "executable_checksum": "sha256:ae0104e99a04cea9fc28d90297c074c67bda0814229c1f5339c88c3f9578d663",
+      "executable_checksum": "sha256:49cc39a6168e9505e9c3c972c3b4c98b28d1e244f3bab28e05897364e2f0d5ab",
       "hooks": [
         "collect"
       ],
@@ -275,7 +275,7 @@
           }
         ]
       },
-      "updated_at_utc": "2026-03-03T00:27:41Z"
+      "updated_at_utc": "2026-03-07T00:41:52Z"
     },
     {
       "id": "builtin/logo",
@@ -286,7 +286,7 @@
       },
       "manifest_checksum": "sha256:af61b58d44701324a9b6f6108b590459e86a3cb4c5135ae1d3353c70364cab31",
       "executable_path": "gobin:builtin-logo-af61b58d4470",
-      "executable_checksum": "sha256:5e3c0adde51cf0538220864aa5d91f35241c192bd6bc1413045bd5f737773d18",
+      "executable_checksum": "sha256:050c56752d3ebbcd8f6392df3be7087858ed948e321b71c6295e7ce9343e851c",
       "hooks": [
         "collect"
       ],
@@ -305,7 +305,7 @@
           }
         ]
       },
-      "updated_at_utc": "2026-03-03T00:27:41Z"
+      "updated_at_utc": "2026-03-07T00:41:52Z"
     },
     {
       "id": "builtin/scopes",
@@ -316,7 +316,7 @@
       },
       "manifest_checksum": "sha256:5b566875df96f23b3e1386da07d5121e5d4d761caec6ad95c678f5335e619b30",
       "executable_path": "gobin:builtin-scopes-5b566875df96",
-      "executable_checksum": "sha256:d2d7ac9480fadcac4db7f663e591886676848e4f2403730374a3aed4cef8041b",
+      "executable_checksum": "sha256:6a249efb63442040a7a689db1466a6748fcffad76401da3e5ea4736ad01b4b41",
       "hooks": [
         "collect",
         "enrich"
@@ -355,7 +355,7 @@
           }
         ]
       },
-      "updated_at_utc": "2026-03-03T00:27:41Z"
+      "updated_at_utc": "2026-03-07T00:41:52Z"
     },
     {
       "id": "builtin/signedoffby",
@@ -366,7 +366,7 @@
       },
       "manifest_checksum": "sha256:b02571782a435fb9295b135a2904004c831957878c2039fc835eb2c2a58d70ce",
       "executable_path": "gobin:builtin-signedoffby-b02571782a43",
-      "executable_checksum": "sha256:5b1bac2c33fab8e273daa089b7e97aeb0a4e713f02ae5bebc2c0d78ce7b56c6d",
+      "executable_checksum": "sha256:78f5c6c094881330d2aad6eed168faa6acdde1ed505cc42097437fd1faf6dbab",
       "hooks": [
         "finalize"
       ],
@@ -385,7 +385,7 @@
           }
         ]
       },
-      "updated_at_utc": "2026-03-03T00:27:41Z"
+      "updated_at_utc": "2026-03-07T00:41:52Z"
     },
     {
       "id": "builtin/types",
@@ -396,7 +396,7 @@
       },
       "manifest_checksum": "sha256:ca08ca9e14f372135bef60555365b5c45554d87dd17e69c1f44b2a050a30eeb7",
       "executable_path": "gobin:builtin-types-ca08ca9e14f3",
-      "executable_checksum": "sha256:d97c6451234472f01692e6c01b621a7836a9dd90876ecf3c33154cfb1081e8f1",
+      "executable_checksum": "sha256:efeec13591ff2e1c2f4d84d113f76d418c9b476e4173e457c731cf2bec98a0b7",
       "hooks": [
         "collect"
       ],
@@ -424,7 +424,7 @@
           }
         ]
       },
-      "updated_at_utc": "2026-03-03T00:27:41Z"
+      "updated_at_utc": "2026-03-07T00:41:52Z"
     },
     {
       "id": "builtin/why",
@@ -435,7 +435,7 @@
       },
       "manifest_checksum": "sha256:8f1d5d5f15b6190a1eb15184bc07252d637c8081dcb0194652bb1f0210259112",
       "executable_path": "gobin:builtin-why-8f1d5d5f15b6",
-      "executable_checksum": "sha256:61c4a83d3100de035955c2d90e83da44303d942c1d00f555f20bb43ec40b414c",
+      "executable_checksum": "sha256:c8eb125432037931bff09fbf4673354920aeefc9c6ff964108f00455b595d2da",
       "hooks": [
         "collect",
         "enrich"
@@ -469,7 +469,7 @@
           }
         ]
       },
-      "updated_at_utc": "2026-03-03T00:27:41Z"
+      "updated_at_utc": "2026-03-07T00:41:52Z"
     }
   ]
 }

--- a/internal/pluginruntime/install.go
+++ b/internal/pluginruntime/install.go
@@ -58,10 +58,14 @@ func BuildLockfileWithArtifacts(resolved []ResolvedPlugin, lockPath, binDirOverr
 
 func installExecutable(lockDir, binDir string, rp ResolvedPlugin) (string, string, error) {
 	target := buildTarget(rp)
-	if target == "" {
-		return "", "", nil
+	if target != "" {
+		return buildExecutableArtifact(lockDir, binDir, rp, target)
 	}
 
+	return lockDirectExecutable(lockDir, rp)
+}
+
+func buildExecutableArtifact(lockDir, binDir string, rp ResolvedPlugin, target string) (string, string, error) {
 	artifactName := sanitizePluginID(rp.Runtime.Manifest.ID)
 	if suffix := artifactNameSuffix(rp); suffix != "" {
 		artifactName += "-" + suffix
@@ -90,8 +94,32 @@ func installExecutable(lockDir, binDir string, rp ResolvedPlugin) (string, strin
 	return storedPath, sum, nil
 }
 
+func lockDirectExecutable(lockDir string, rp ResolvedPlugin) (string, string, error) {
+	execPath, err := resolveDirectExecutablePath(lockDir, rp)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve plugin executable %s: %w", rp.Runtime.Manifest.ID, err)
+	}
+	if execPath == "" {
+		if requiresExecutablePin(rp) {
+			return "", "", fmt.Errorf("plugin %s uses source.type=path but no lockable executable was found", rp.Runtime.Manifest.ID)
+		}
+		return "", "", nil
+	}
+
+	sum, err := FileSHA256(execPath)
+	if err != nil {
+		return "", "", fmt.Errorf("checksum plugin executable %s: %w", rp.Runtime.Manifest.ID, err)
+	}
+	storedPath, err := pathForLockfile(lockDir, filepath.Dir(execPath), execPath)
+	if err != nil {
+		return "", "", fmt.Errorf("path for plugin executable %s: %w", rp.Runtime.Manifest.ID, err)
+	}
+	return storedPath, sum, nil
+}
+
 func buildPluginArtifact(artifactPath, target, moduleRef string) error {
-	stderr, err := runGoBuild("", artifactPath, target)
+	buildDir, buildTarget := prepareGoBuildInvocation(target)
+	stderr, err := runGoBuild(buildDir, artifactPath, buildTarget)
 	if err == nil {
 		return nil
 	}
@@ -103,6 +131,61 @@ func buildPluginArtifact(artifactPath, target, moduleRef string) error {
 		return fmt.Errorf("%w stderr=%s (fallback stderr=%s)", err, strings.TrimSpace(stderr), strings.TrimSpace(tempStderr))
 	}
 	return fmt.Errorf("%w stderr=%s", err, strings.TrimSpace(stderr))
+}
+
+func prepareGoBuildInvocation(target string) (string, string) {
+	localTarget, ok := resolveLocalBuildTarget(target)
+	if !ok {
+		return "", target
+	}
+
+	buildDir := filepath.Dir(localTarget)
+	if moduleDir := findGoModuleDir(localTarget); moduleDir != "" {
+		buildDir = moduleDir
+	}
+
+	relTarget, err := filepath.Rel(buildDir, localTarget)
+	if err != nil {
+		return buildDir, localTarget
+	}
+	if relTarget == "." {
+		return buildDir, "."
+	}
+	if !strings.HasPrefix(relTarget, ".") {
+		relTarget = "." + string(filepath.Separator) + relTarget
+	}
+	return buildDir, relTarget
+}
+
+func resolveLocalBuildTarget(target string) (string, bool) {
+	trimmed := strings.TrimSpace(target)
+	if trimmed == "" || isModuleImportTarget(trimmed) {
+		return "", false
+	}
+	if filepath.IsAbs(trimmed) {
+		return filepath.Clean(trimmed), true
+	}
+	if strings.HasPrefix(trimmed, ".") || strings.HasPrefix(trimmed, "..") || strings.ContainsAny(trimmed, `/\`) {
+		absTarget, err := filepath.Abs(trimmed)
+		if err == nil {
+			return absTarget, true
+		}
+	}
+	return "", false
+}
+
+func findGoModuleDir(target string) string {
+	dir := target
+	for {
+		if info, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil && !info.IsDir() {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
 }
 
 func runGoBuild(dir, artifactPath, target string) (string, error) {
@@ -223,6 +306,69 @@ func pathForLockfile(lockDir, binDir, artifactPath string) (string, error) {
 	}
 
 	return filepath.ToSlash(artifactPath), nil
+}
+
+func resolveDirectExecutablePath(lockDir string, rp ResolvedPlugin) (string, error) {
+	candidates := []string{rp.Runtime.Manifest.Entrypoint.Command}
+	if strings.TrimSpace(rp.Source.Path) != "" {
+		candidates = append(candidates, rp.Source.Path)
+	}
+
+	seen := map[string]bool{}
+	var firstErr error
+	for _, raw := range candidates {
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" || seen[trimmed] {
+			continue
+		}
+		seen[trimmed] = true
+
+		resolved, err := resolveExecutableCandidate(lockDir, trimmed)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		info, err := os.Stat(resolved)
+		if err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if info.IsDir() {
+			if firstErr == nil {
+				firstErr = fmt.Errorf("%s is a directory, not an executable", resolved)
+			}
+			continue
+		}
+		return resolved, nil
+	}
+
+	return "", firstErr
+}
+
+func resolveExecutableCandidate(lockDir, raw string) (string, error) {
+	if raw == "" {
+		return "", nil
+	}
+	if filepath.IsAbs(raw) {
+		return raw, nil
+	}
+	if strings.ContainsAny(raw, `/\`) {
+		return filepath.Abs(filepath.Join(lockDir, filepath.FromSlash(raw)))
+	}
+
+	resolved, err := exec.LookPath(raw)
+	if err != nil {
+		return "", fmt.Errorf("locate %q on PATH: %w", raw, err)
+	}
+	return resolved, nil
+}
+
+func requiresExecutablePin(rp ResolvedPlugin) bool {
+	return rp.Source.Type == "path" && buildTarget(rp) == ""
 }
 
 func buildTarget(rp ResolvedPlugin) string {

--- a/internal/pluginruntime/install.go
+++ b/internal/pluginruntime/install.go
@@ -309,10 +309,11 @@ func pathForLockfile(lockDir, binDir, artifactPath string) (string, error) {
 }
 
 func resolveDirectExecutablePath(lockDir string, rp ResolvedPlugin) (string, error) {
-	candidates := []string{rp.Runtime.Manifest.Entrypoint.Command}
+	candidates := []string{}
 	if strings.TrimSpace(rp.Source.Path) != "" {
 		candidates = append(candidates, rp.Source.Path)
 	}
+	candidates = append(candidates, rp.Runtime.Manifest.Entrypoint.Command)
 
 	seen := map[string]bool{}
 	var firstErr error

--- a/internal/pluginruntime/manifest.go
+++ b/internal/pluginruntime/manifest.go
@@ -37,8 +37,8 @@ func ParseManifest(raw []byte) (Manifest, error) {
 	if err := validateManifest(m); err != nil {
 		return Manifest{}, err
 	}
-	if len(m.ProtocolVersions) == 0 {
-		m.ProtocolVersions = []string{ProtocolVersionV1}
+	if err := normalizeAndValidateProtocol(&m); err != nil {
+		return Manifest{}, err
 	}
 	return m, nil
 }
@@ -50,4 +50,14 @@ func SupportsProtocol(m Manifest, protocol string) bool {
 		}
 	}
 	return false
+}
+
+func normalizeAndValidateProtocol(m *Manifest) error {
+	if len(m.ProtocolVersions) == 0 {
+		m.ProtocolVersions = []string{ProtocolVersionV1}
+	}
+	if SupportsProtocol(*m, ProtocolVersionV1) {
+		return nil
+	}
+	return fmt.Errorf("manifest %s does not support protocol version %s", m.ID, ProtocolVersionV1)
 }

--- a/internal/pluginruntime/path_resolution_test.go
+++ b/internal/pluginruntime/path_resolution_test.go
@@ -190,6 +190,84 @@ func TestVerifyResolvedPluginsRejectsTamperedDirectExecutablePathPlugins(t *test
 	}
 }
 
+func TestInterpreterStylePathPluginsPinScriptAndPreserveCommand(t *testing.T) {
+	lockDir := t.TempDir()
+	lockPath := filepath.Join(lockDir, "goodcommit.plugins.lock")
+	pluginPath := filepath.Join(lockDir, "plugins", "my-plugin.py")
+	if err := os.MkdirAll(filepath.Dir(pluginPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(pluginPath, []byte("print('ok')\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	resolved := []ResolvedPlugin{{
+		Runtime: RuntimePlugin{
+			Manifest: Manifest{
+				APIVersion: "goodcommit.io/v1",
+				Kind:       "Plugin",
+				ID:         "test/interpreter-path",
+				Version:    "1.0.0",
+				Entrypoint: EntryPoint{
+					Type:    "exec",
+					Command: "python3",
+					Args:    []string{"./plugins/my-plugin.py", "--serve"},
+				},
+				Hooks:            []HookPhase{HookCollect},
+				ProtocolVersions: []string{ProtocolVersionV1},
+			},
+		},
+		Source: LockedSource{
+			Type: "path",
+			Path: "./plugins/my-plugin.py",
+		},
+		ManifestSHA: "sha256:fedcba9876543210",
+	}}
+
+	lf, err := BuildLockfileWithArtifacts(resolved, lockPath, "project")
+	if err != nil {
+		t.Fatalf("BuildLockfileWithArtifacts() error = %v", err)
+	}
+	if len(lf.Plugins) != 1 {
+		t.Fatalf("lockfile plugins = %d, want 1", len(lf.Plugins))
+	}
+	lockedExecPath, err := resolveExecutablePath(lockDir, lf.Plugins[0].ExecutablePath)
+	if err != nil {
+		t.Fatalf("resolveExecutablePath() error = %v", err)
+	}
+	if lockedExecPath != pluginPath {
+		t.Fatalf("locked executable path = %q, want %q", lockedExecPath, pluginPath)
+	}
+	if err := WriteLockfile(lockPath, lf); err != nil {
+		t.Fatalf("WriteLockfile() error = %v", err)
+	}
+	if err := VerifyResolvedPlugins(resolved, lockPath); err != nil {
+		t.Fatalf("VerifyResolvedPlugins() error = %v", err)
+	}
+
+	runtimePlugins, err := RuntimePluginsFromLock(resolved, lockPath)
+	if err != nil {
+		t.Fatalf("RuntimePluginsFromLock() error = %v", err)
+	}
+	if got := runtimePlugins[0].Manifest.Entrypoint.Command; got != "python3" {
+		t.Fatalf("runtime command = %q, want %q", got, "python3")
+	}
+	if got := runtimePlugins[0].Manifest.Entrypoint.Args; len(got) != 2 || got[0] != "./plugins/my-plugin.py" || got[1] != "--serve" {
+		t.Fatalf("runtime args = %#v, want preserved interpreter args", got)
+	}
+
+	if err := os.WriteFile(pluginPath, []byte("print('tampered')\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	err = VerifyResolvedPlugins(resolved, lockPath)
+	if err == nil {
+		t.Fatalf("expected VerifyResolvedPlugins() error")
+	}
+	if !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestVerifyResolvedPluginsRejectsUnpinnedDirectExecutablePathPlugins(t *testing.T) {
 	lockDir := t.TempDir()
 	lockPath := filepath.Join(lockDir, "goodcommit.plugins.lock")

--- a/internal/pluginruntime/path_resolution_test.go
+++ b/internal/pluginruntime/path_resolution_test.go
@@ -1,6 +1,7 @@
 package pluginruntime
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -67,5 +68,169 @@ func TestResolveExecutablePathRelative(t *testing.T) {
 	}
 	if !strings.HasSuffix(got, filepath.Join("plugins", "bin", "my-plugin")) {
 		t.Fatalf("resolveExecutablePath() unexpected suffix: %q", got)
+	}
+}
+
+func TestBuildLockfileWithArtifactsLocksDirectExecutablePathPlugins(t *testing.T) {
+	lockDir := t.TempDir()
+	lockPath := filepath.Join(lockDir, "goodcommit.plugins.lock")
+	pluginPath := filepath.Join(lockDir, "plugins", "my-plugin.sh")
+	if err := os.MkdirAll(filepath.Dir(pluginPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(pluginPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	resolved := []ResolvedPlugin{{
+		Runtime: RuntimePlugin{
+			Manifest: Manifest{
+				APIVersion: "goodcommit.io/v1",
+				Kind:       "Plugin",
+				ID:         "test/direct-exec",
+				Version:    "1.0.0",
+				Entrypoint: EntryPoint{
+					Type:    "exec",
+					Command: "./plugins/my-plugin.sh",
+					Args:    []string{"serve"},
+				},
+				Hooks:            []HookPhase{HookCollect},
+				ProtocolVersions: []string{ProtocolVersionV1},
+			},
+		},
+		Source: LockedSource{
+			Type: "path",
+			Path: "./plugins/my-plugin.sh",
+		},
+		ManifestSHA: "sha256:0123456789abcdef",
+	}}
+
+	lf, err := BuildLockfileWithArtifacts(resolved, lockPath, "project")
+	if err != nil {
+		t.Fatalf("BuildLockfileWithArtifacts() error = %v", err)
+	}
+	if len(lf.Plugins) != 1 {
+		t.Fatalf("lockfile plugins = %d, want 1", len(lf.Plugins))
+	}
+	if lf.Plugins[0].ExecutablePath == "" {
+		t.Fatalf("ExecutablePath should be populated for direct exec path plugins")
+	}
+	if lf.Plugins[0].ExecutableChecksum == "" {
+		t.Fatalf("ExecutableChecksum should be populated for direct exec path plugins")
+	}
+	if err := WriteLockfile(lockPath, lf); err != nil {
+		t.Fatalf("WriteLockfile() error = %v", err)
+	}
+	if err := VerifyResolvedPlugins(resolved, lockPath); err != nil {
+		t.Fatalf("VerifyResolvedPlugins() error = %v", err)
+	}
+
+	runtimePlugins, err := RuntimePluginsFromLock(resolved, lockPath)
+	if err != nil {
+		t.Fatalf("RuntimePluginsFromLock() error = %v", err)
+	}
+	if got := runtimePlugins[0].Manifest.Entrypoint.Command; got != pluginPath {
+		t.Fatalf("runtime command = %q, want %q", got, pluginPath)
+	}
+	if len(runtimePlugins[0].Manifest.Entrypoint.Args) != 1 || runtimePlugins[0].Manifest.Entrypoint.Args[0] != "serve" {
+		t.Fatalf("runtime args = %#v, want preserved direct-exec args", runtimePlugins[0].Manifest.Entrypoint.Args)
+	}
+}
+
+func TestVerifyResolvedPluginsRejectsTamperedDirectExecutablePathPlugins(t *testing.T) {
+	lockDir := t.TempDir()
+	lockPath := filepath.Join(lockDir, "goodcommit.plugins.lock")
+	pluginPath := filepath.Join(lockDir, "plugins", "my-plugin.sh")
+	if err := os.MkdirAll(filepath.Dir(pluginPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(pluginPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	resolved := []ResolvedPlugin{{
+		Runtime: RuntimePlugin{
+			Manifest: Manifest{
+				APIVersion: "goodcommit.io/v1",
+				Kind:       "Plugin",
+				ID:         "test/direct-exec",
+				Version:    "1.0.0",
+				Entrypoint: EntryPoint{
+					Type:    "exec",
+					Command: "./plugins/my-plugin.sh",
+				},
+				Hooks:            []HookPhase{HookCollect},
+				ProtocolVersions: []string{ProtocolVersionV1},
+			},
+		},
+		Source: LockedSource{
+			Type: "path",
+			Path: "./plugins/my-plugin.sh",
+		},
+		ManifestSHA: "sha256:0123456789abcdef",
+	}}
+
+	lf, err := BuildLockfileWithArtifacts(resolved, lockPath, "project")
+	if err != nil {
+		t.Fatalf("BuildLockfileWithArtifacts() error = %v", err)
+	}
+	if err := WriteLockfile(lockPath, lf); err != nil {
+		t.Fatalf("WriteLockfile() error = %v", err)
+	}
+	if err := os.WriteFile(pluginPath, []byte("#!/bin/sh\necho changed\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	err = VerifyResolvedPlugins(resolved, lockPath)
+	if err == nil {
+		t.Fatalf("expected VerifyResolvedPlugins() error")
+	}
+	if !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestVerifyResolvedPluginsRejectsUnpinnedDirectExecutablePathPlugins(t *testing.T) {
+	lockDir := t.TempDir()
+	lockPath := filepath.Join(lockDir, "goodcommit.plugins.lock")
+	resolved := []ResolvedPlugin{{
+		Runtime: RuntimePlugin{
+			Manifest: Manifest{
+				APIVersion: "goodcommit.io/v1",
+				Kind:       "Plugin",
+				ID:         "test/direct-exec",
+				Version:    "1.0.0",
+				Entrypoint: EntryPoint{
+					Type:    "exec",
+					Command: "./plugins/my-plugin.sh",
+				},
+				Hooks:            []HookPhase{HookCollect},
+				ProtocolVersions: []string{ProtocolVersionV1},
+			},
+		},
+		Source: LockedSource{
+			Type: "path",
+			Path: "./plugins/my-plugin.sh",
+		},
+		ManifestSHA: "sha256:0123456789abcdef",
+	}}
+
+	lf := NewLockfile()
+	lf.UpsertPlugin(LockedPlugin{
+		ID:               "test/direct-exec",
+		Version:          "1.0.0",
+		Source:           LockedSource{Type: "path", Path: "./plugins/my-plugin.sh"},
+		ManifestChecksum: "sha256:0123456789abcdef",
+	})
+	if err := WriteLockfile(lockPath, lf); err != nil {
+		t.Fatalf("WriteLockfile() error = %v", err)
+	}
+
+	err := VerifyResolvedPlugins(resolved, lockPath)
+	if err == nil {
+		t.Fatalf("expected VerifyResolvedPlugins() error")
+	}
+	if !strings.Contains(err.Error(), "missing executable path") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/internal/pluginruntime/protocol_test.go
+++ b/internal/pluginruntime/protocol_test.go
@@ -1,0 +1,66 @@
+package pluginruntime
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestParseManifestRejectsUnsupportedProtocol(t *testing.T) {
+	raw := []byte(`{
+  "api_version": "goodcommit.io/v1",
+  "kind": "Plugin",
+  "id": "test/protocol",
+  "version": "1.0.0",
+  "protocol_versions": ["2.0"],
+  "entrypoint": {
+    "type": "exec",
+    "command": "echo"
+  },
+  "hooks": ["collect"]
+}`)
+
+	_, err := ParseManifest(raw)
+	if err == nil {
+		t.Fatalf("expected ParseManifest() error")
+	}
+	if !strings.Contains(err.Error(), "does not support protocol version") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestInvokeRejectsUnsupportedProtocolWhenManifestConstructedProgrammatically(t *testing.T) {
+	runner := NewRunner()
+	rp := RuntimePlugin{
+		Manifest: Manifest{
+			APIVersion:       "goodcommit.io/v1",
+			Kind:             "Plugin",
+			ID:               "test/protocol",
+			Version:          "1.0.0",
+			ProtocolVersions: []string{"2.0"},
+			Entrypoint: EntryPoint{
+				Type:    "exec",
+				Command: "echo",
+			},
+			Hooks: []HookPhase{HookCollect},
+		},
+	}
+	req := Request{
+		ProtocolVersion: ProtocolVersionV1,
+		RequestID:       "req-1",
+		PluginID:        "test/protocol",
+		Hook:            HookCollect,
+		Context: RequestContext{
+			RepoRoot: t.TempDir(),
+		},
+		Draft: CommitDraft{Metadata: map[string]interface{}{}},
+	}
+
+	_, err := runner.Invoke(context.Background(), rp, req)
+	if err == nil {
+		t.Fatalf("expected Invoke() error")
+	}
+	if !strings.Contains(err.Error(), "does not support protocol version") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/pluginruntime/runner.go
+++ b/internal/pluginruntime/runner.go
@@ -316,16 +316,20 @@ func (r *Runner) handlePluginUIRequests(pluginID string, resp Response) (map[str
 
 // Invoke executes a single plugin process.
 func (r *Runner) Invoke(ctx context.Context, rp RuntimePlugin, req Request) (Invocation, error) {
-	if err := validateManifest(rp.Manifest); err != nil {
-		return Invocation{}, fmt.Errorf("manifest validation failed for %s: %w", rp.Manifest.ID, err)
+	manifest := rp.Manifest
+	if err := normalizeAndValidateProtocol(&manifest); err != nil {
+		return Invocation{}, fmt.Errorf("manifest protocol validation failed for %s: %w", rp.Manifest.ID, err)
 	}
-	if !supportsHook(rp.Manifest.Hooks, req.Hook) {
-		return Invocation{}, fmt.Errorf("plugin %s does not support hook %s", rp.Manifest.ID, req.Hook)
+	if err := validateManifest(manifest); err != nil {
+		return Invocation{}, fmt.Errorf("manifest validation failed for %s: %w", manifest.ID, err)
+	}
+	if !supportsHook(manifest.Hooks, req.Hook) {
+		return Invocation{}, fmt.Errorf("plugin %s does not support hook %s", manifest.ID, req.Hook)
 	}
 	if err := validateRequest(req); err != nil {
 		return Invocation{}, fmt.Errorf("request validation failed: %w", err)
 	}
-	if err := r.checkPermissions(rp.Manifest.ID, rp.Manifest.Permissions); err != nil {
+	if err := r.checkPermissions(manifest.ID, manifest.Permissions); err != nil {
 		return Invocation{}, err
 	}
 
@@ -344,10 +348,10 @@ func (r *Runner) Invoke(ctx context.Context, rp RuntimePlugin, req Request) (Inv
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, rp.Manifest.Entrypoint.Command, rp.Manifest.Entrypoint.Args...)
+	cmd := exec.CommandContext(ctx, manifest.Entrypoint.Command, manifest.Entrypoint.Args...)
 	cmd.Stdin = bytes.NewReader(rawReq)
 	cmd.Dir = req.Context.RepoRoot
-	cmd.Env = buildPluginEnv(rp.Manifest.Permissions.Secrets, rp.Manifest.Entrypoint.Env)
+	cmd.Env = buildPluginEnv(manifest.Permissions.Secrets, manifest.Entrypoint.Env)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -358,9 +362,9 @@ func (r *Runner) Invoke(ctx context.Context, rp RuntimePlugin, req Request) (Inv
 	duration := time.Since(start)
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {
-			return Invocation{}, fmt.Errorf("plugin %s timed out after %s", rp.Manifest.ID, timeout)
+			return Invocation{}, fmt.Errorf("plugin %s timed out after %s", manifest.ID, timeout)
 		}
-		return Invocation{}, fmt.Errorf("plugin %s failed: %w stderr=%s", rp.Manifest.ID, err, stderr.String())
+		return Invocation{}, fmt.Errorf("plugin %s failed: %w stderr=%s", manifest.ID, err, stderr.String())
 	}
 
 	maxOut := r.MaxOutputBytes
@@ -368,19 +372,19 @@ func (r *Runner) Invoke(ctx context.Context, rp RuntimePlugin, req Request) (Inv
 		maxOut = defaultMaxOutputSize
 	}
 	if stdout.Len() > maxOut {
-		return Invocation{}, fmt.Errorf("plugin %s output exceeded max size %d", rp.Manifest.ID, maxOut)
+		return Invocation{}, fmt.Errorf("plugin %s output exceeded max size %d", manifest.ID, maxOut)
 	}
 
 	var resp Response
 	if err := json.Unmarshal(stdout.Bytes(), &resp); err != nil {
-		return Invocation{}, fmt.Errorf("invalid plugin response from %s: %w stderr=%s", rp.Manifest.ID, err, stderr.String())
+		return Invocation{}, fmt.Errorf("invalid plugin response from %s: %w stderr=%s", manifest.ID, err, stderr.String())
 	}
 	if err := validateResponse(resp, req); err != nil {
-		return Invocation{}, fmt.Errorf("response validation failed for %s: %w", rp.Manifest.ID, err)
+		return Invocation{}, fmt.Errorf("response validation failed for %s: %w", manifest.ID, err)
 	}
 
 	return Invocation{
-		PluginID: rp.Manifest.ID,
+		PluginID: manifest.ID,
 		Hook:     req.Hook,
 		Response: resp,
 		Stderr:   stderr.String(),

--- a/internal/pluginruntime/verify.go
+++ b/internal/pluginruntime/verify.go
@@ -67,6 +67,9 @@ func VerifyResolvedPlugins(resolved []ResolvedPlugin, lockPath string) error {
 		if !sameSource(locked.Source, rp.Source) {
 			return fmt.Errorf("source mismatch for plugin %s", rp.Runtime.Manifest.ID)
 		}
+		if locked.ExecutablePath == "" && requiresExecutablePin(rp) {
+			return fmt.Errorf("lockfile missing executable path for plugin %s; re-run plugin lock", rp.Runtime.Manifest.ID)
+		}
 		if locked.ExecutablePath != "" {
 			execPath, err := resolveExecutablePath(filepath.Dir(lockPath), locked.ExecutablePath)
 			if err != nil {
@@ -99,13 +102,18 @@ func RuntimePluginsFromLock(resolved []ResolvedPlugin, lockPath string) ([]Runti
 		if !ok {
 			return nil, fmt.Errorf("plugin %s missing from lockfile", runtimePlugin.Manifest.ID)
 		}
+		if locked.ExecutablePath == "" && requiresExecutablePin(rp) {
+			return nil, fmt.Errorf("lockfile missing executable path for plugin %s; re-run plugin lock", runtimePlugin.Manifest.ID)
+		}
 		if locked.ExecutablePath != "" {
 			execPath, err := resolveExecutablePath(lockDir, locked.ExecutablePath)
 			if err != nil {
 				return nil, fmt.Errorf("resolve executable path for %s: %w", runtimePlugin.Manifest.ID, err)
 			}
 			runtimePlugin.Manifest.Entrypoint.Command = execPath
-			runtimePlugin.Manifest.Entrypoint.Args = nil
+			if buildTarget(rp) != "" {
+				runtimePlugin.Manifest.Entrypoint.Args = nil
+			}
 		}
 		out = append(out, runtimePlugin)
 	}

--- a/internal/pluginruntime/verify.go
+++ b/internal/pluginruntime/verify.go
@@ -110,7 +110,9 @@ func RuntimePluginsFromLock(resolved []ResolvedPlugin, lockPath string) ([]Runti
 			if err != nil {
 				return nil, fmt.Errorf("resolve executable path for %s: %w", runtimePlugin.Manifest.ID, err)
 			}
-			runtimePlugin.Manifest.Entrypoint.Command = execPath
+			if shouldRewriteEntrypointCommand(lockDir, rp, execPath) {
+				runtimePlugin.Manifest.Entrypoint.Command = execPath
+			}
 			if buildTarget(rp) != "" {
 				runtimePlugin.Manifest.Entrypoint.Args = nil
 			}
@@ -119,6 +121,18 @@ func RuntimePluginsFromLock(resolved []ResolvedPlugin, lockPath string) ([]Runti
 	}
 
 	return out, nil
+}
+
+func shouldRewriteEntrypointCommand(lockDir string, rp ResolvedPlugin, lockedExecPath string) bool {
+	if buildTarget(rp) != "" {
+		return true
+	}
+
+	commandPath, err := resolveExecutableCandidate(lockDir, strings.TrimSpace(rp.Runtime.Manifest.Entrypoint.Command))
+	if err != nil {
+		return false
+	}
+	return samePath(commandPath, lockedExecPath)
 }
 
 func sameSource(a, b LockedSource) bool {

--- a/internal/pluginutil/text.go
+++ b/internal/pluginutil/text.go
@@ -1,0 +1,27 @@
+package pluginutil
+
+import (
+	"unicode"
+	"unicode/utf8"
+)
+
+func UppercaseFirstRune(s string) string {
+	return mapFirstRune(s, unicode.ToUpper)
+}
+
+func LowercaseFirstRune(s string) string {
+	return mapFirstRune(s, unicode.ToLower)
+}
+
+func mapFirstRune(s string, mapper func(rune) rune) string {
+	if s == "" {
+		return ""
+	}
+
+	r, size := utf8.DecodeRuneInString(s)
+	if r == utf8.RuneError && size <= 1 {
+		return s
+	}
+
+	return string(mapper(r)) + s[size:]
+}

--- a/internal/pluginutil/text_test.go
+++ b/internal/pluginutil/text_test.go
@@ -1,0 +1,37 @@
+package pluginutil
+
+import "testing"
+
+func TestUppercaseFirstRuneASCII(t *testing.T) {
+	if got := UppercaseFirstRune("hello"); got != "Hello" {
+		t.Fatalf("UppercaseFirstRune() = %q, want %q", got, "Hello")
+	}
+}
+
+func TestUppercaseFirstRuneUTF8(t *testing.T) {
+	if got := UppercaseFirstRune("áccent"); got != "Áccent" {
+		t.Fatalf("UppercaseFirstRune() = %q, want %q", got, "Áccent")
+	}
+}
+
+func TestLowercaseFirstRuneASCII(t *testing.T) {
+	if got := LowercaseFirstRune("Hello"); got != "hello" {
+		t.Fatalf("LowercaseFirstRune() = %q, want %q", got, "hello")
+	}
+}
+
+func TestLowercaseFirstRuneUTF8(t *testing.T) {
+	if got := LowercaseFirstRune("Ñandú"); got != "ñandú" {
+		t.Fatalf("LowercaseFirstRune() = %q, want %q", got, "ñandú")
+	}
+}
+
+func TestCaseHelpersPreserveInvalidUTF8Prefix(t *testing.T) {
+	raw := string([]byte{0xff, 'A', 'B'})
+	if got := UppercaseFirstRune(raw); got != raw {
+		t.Fatalf("UppercaseFirstRune() changed invalid input: got %q want %q", got, raw)
+	}
+	if got := LowercaseFirstRune(raw); got != raw {
+		t.Fatalf("LowercaseFirstRune() changed invalid input: got %q want %q", got, raw)
+	}
+}


### PR DESCRIPTION
## Summary
- fix UTF-8 first-rune normalization in built-in text plugins
- enforce manifest protocol compatibility before plugin execution
- pin and verify direct executable path plugins, and fix local Go path plugin builds
- add non-interactive CLI integration coverage for common and edge-case flows
- clarify the advisory plugin permission model and add changelog/release prep for v0.3.2
- add GitHub Actions CI for test, build, plugin lock, and plugin verify

## Validation
- go test ./...
- go build ./...
- go run ./cmd/goodcommit plugin lock --plugins-config ./configs/goodcommit.plugins.json --plugins-lockfile ./goodcommit.plugins.lock
- go run ./cmd/goodcommit plugin verify --plugins-config ./configs/goodcommit.plugins.json --plugins-lockfile ./goodcommit.plugins.lock
